### PR TITLE
Switch to callPackage

### DIFF
--- a/back/default.nix
+++ b/back/default.nix
@@ -1,18 +1,26 @@
-with (import <nixpkgs> { }); let
-  workadventure-messages = import ../messages;
+{ stdenv
+, autoPatchelfHook
+, fetchFromGitHub
+, fetchzip
+, makeWrapper
+, nodejs-14_x
+, workadventure-messages
+, yarn2nix-moretea
+, ... }:
 
+let
   node-abi = "83";
 
-  node-grpc-precompiled = pkgs.fetchzip {
+  node-grpc-precompiled = fetchzip {
     name = "node-grpc-precompiled-node-${node-abi}";
     url = "https://node-precompiled-binaries.grpc.io/grpc/v1.24.4/node-v${node-abi}-linux-x64-glibc.tar.gz";
     sha256 = "119rhhk1jpi2vwyim7byq3agacasc4q25c26wyzfmy8vk2ih6ndj";
   };
 
-  node-grpc-patched = pkgs.stdenv.mkDerivation {
+  node-grpc-patched = stdenv.mkDerivation {
     name = "node-grpc";
     buildInputs = [ stdenv.cc.cc ];
-    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+    nativeBuildInputs = [ autoPatchelfHook ];
     dontUnpack = true;
     # spams console
     dontStrip = true;

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+with import <nixpkgs> {};
+lib.fix (self: let
+  callPackage = lib.callPackageWith self;
+in pkgs // {
+  workadventure-back = callPackage ./back {};
+  workadventure-pusher = callPackage ./pusher {};
+  workadventure-messages = callPackage ./messages {};
+  workadventure-front = callPackage ./front {};
+  workadventure-uploader = callPackage ./uploader {};
+  workadventure-maps = callPackage ./maps {};
+})

--- a/front/default.nix
+++ b/front/default.nix
@@ -1,6 +1,9 @@
-with (import <nixpkgs> { }); let
-  workadventure-messages = import ../messages;
-in
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, workadventure-messages
+, yarn2nix-moretea
+, ... }:
 yarn2nix-moretea.mkYarnPackage rec {
   pname = "workadventurefront";
   version = "unstable";

--- a/maps/default.nix
+++ b/maps/default.nix
@@ -1,4 +1,8 @@
-with (import <nixpkgs> { });
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, yarn2nix-moretea
+, ... }:
 
 yarn2nix-moretea.mkYarnPackage rec {
   pname = "workadventuremaps";

--- a/messages/default.nix
+++ b/messages/default.nix
@@ -1,14 +1,22 @@
-with (import <nixpkgs> { }); let
-  node-protoc-precompiled = pkgs.fetchzip {
+{ stdenv
+, autoPatchelfHook
+, fetchFromGitHub
+, fetchzip
+, gcc-unwrapped
+, yarn2nix-moretea
+, ... }:
+
+let
+  node-protoc-precompiled = fetchzip {
     name = "node-protoc-precompiled";
     url = "https://node-precompiled-binaries.grpc.io/grpc-tools/v1.10.0/linux-x64.tar.gz";
     sha256 = "0dl1anpw3610q58mxf7r9dcp768krwvpa4053cjxn5r8b5xfbh4l";
   };
 
-  node-protoc-patched = pkgs.stdenv.mkDerivation {
+  node-protoc-patched = stdenv.mkDerivation {
     name = "node-protoc";
-    buildInputs = [ pkgs.gcc-unwrapped.lib ];
-    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+    buildInputs = [ gcc-unwrapped.lib ];
+    nativeBuildInputs = [ autoPatchelfHook ];
     dontAutoPatchelf = true;
     dontUnpack = true;
     # protoc: symbol lookup error: /nix/store/...-node-protoc/bin/protoc: undefined symbol: , version

--- a/pusher/default.nix
+++ b/pusher/default.nix
@@ -1,18 +1,29 @@
-with (import <nixpkgs> { }); let
-  workadventure-messages = import ../messages;
+{ stdenv
+, autoPatchelfHook
+, makeWrapper
 
+, fetchzip
+, fetchFromGitHub
+
+, nodejs-14_x
+, yarn2nix-moretea
+
+, workadventure-messages
+}:
+
+let
   node-abi = "83";
 
-  node-grpc-precompiled = pkgs.fetchzip {
+  node-grpc-precompiled = fetchzip {
     name = "node-grpc-precompiled-node-${node-abi}";
     url = "https://node-precompiled-binaries.grpc.io/grpc/v1.24.4/node-v${node-abi}-linux-x64-glibc.tar.gz";
     sha256 = "119rhhk1jpi2vwyim7byq3agacasc4q25c26wyzfmy8vk2ih6ndj";
   };
 
-  node-grpc-patched = pkgs.stdenv.mkDerivation {
+  node-grpc-patched = stdenv.mkDerivation {
     name = "node-grpc";
     buildInputs = [ stdenv.cc.cc ];
-    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+    nativeBuildInputs = [ autoPatchelfHook ];
     dontUnpack = true;
     # spams console
     dontStrip = true;

--- a/uploader/default.nix
+++ b/uploader/default.nix
@@ -1,4 +1,11 @@
-with (import <nixpkgs> { });
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, mkYarnPackage
+, nodejs-14_x
+, workadventure-messages
+, yarn2nix-moretea
+, ... }:
 
 yarn2nix-moretea.mkYarnPackage rec {
   pname = "workadventureuploader";


### PR DESCRIPTION
This switches all .nix files to be callPackage-compatible functions, and adds a top-level default.nix that ties them all together.